### PR TITLE
Interactive Credential Setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "format": "phpcbf",
         "test:setup": "bash bin/install-wp-tests.sh ${DB_NAME:-test_db} ${DB_USER:-root} ${DB_PASS:-''} ${DB_HOST:-localhost}",
         "test": [
-            "@composer dump-autoload -o",
+            "composer dump-autoload -o",
             "phpunit"
         ]
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
     "autoload-dev": {
         "psr-4": {
             "WooCommerce\\Migrator\\Tests\\": "tests/"
-        }
+        },
+        "exclude-from-classmap": [
+            "tests/wp-cli-stubs.php",
+            "tests/wp-cli-exit-exception-stub.php"
+        ]
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -33,6 +37,9 @@
         "lint": "phpcs",
         "format": "phpcbf",
         "test:setup": "bash bin/install-wp-tests.sh ${DB_NAME:-test_db} ${DB_USER:-root} ${DB_PASS:-''} ${DB_HOST:-localhost}",
-        "test": "phpunit"
+        "test": [
+            "@composer dump-autoload -o",
+            "phpunit"
+        ]
     }
 }

--- a/src/CLI/Commands/class-base-command.php
+++ b/src/CLI/Commands/class-base-command.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Base command class.
+ *
+ * @package WooCommerce\Migrator\CLI\Commands
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Migrator\CLI\Commands;
+
+use WP_CLI;
+
+/**
+ * Abstract base class for migrator commands.
+ */
+abstract class BaseCommand {
+
+	/**
+	 * Determines the platform to use, defaulting to 'shopify'.
+	 *
+	 * @param array $assoc_args Associative arguments from the command.
+	 *
+	 * @return string The platform slug.
+	 */
+	protected function get_platform( array $assoc_args ): string {
+		$platform = $assoc_args['platform'] ?? null;
+		if ( is_null( $platform ) ) {
+			$platform = 'shopify';
+			WP_CLI::log( "Platform not specified, using default: '{$platform}'." );
+		}
+
+		return $platform;
+	}
+}

--- a/src/CLI/Commands/class-base-command.php
+++ b/src/CLI/Commands/class-base-command.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WooCommerce\Migrator\CLI\Commands;
 
+use WooCommerce\Migrator\CLI\CredentialManager;
 use WP_CLI;
 
 /**
@@ -31,5 +32,31 @@ abstract class BaseCommand {
 		}
 
 		return $platform;
+	}
+
+	/**
+	 * Handles the interactive credential setup process.
+	 *
+	 * @param string $platform The platform slug.
+	 *
+	 * @return void
+	 */
+	protected function handle_credential_setup( string $platform ): void {
+		$manager = new CredentialManager( $platform );
+
+		// For now, we only support Shopify.
+		if ( 'shopify' !== $platform ) {
+			WP_CLI::error( "The specified platform '{$platform}' is not supported for setup." );
+		}
+
+		WP_CLI::log( 'Configuring credentials for ' . ucfirst( $platform ) . '...' );
+
+		$required_fields = array(
+			'api_key'  => 'Enter your Shopify API Access Token:',
+			'shop_url' => 'Enter your Shopify store URL (e.g., my-store.myshopify.com):',
+		);
+
+		$credentials = $manager->prompt_for_credentials( $required_fields );
+		$manager->save_credentials( $credentials );
 	}
 }

--- a/src/CLI/Commands/class-products-command.php
+++ b/src/CLI/Commands/class-products-command.php
@@ -39,20 +39,7 @@ class ProductsCommand extends BaseCommand {
 
 		if ( ! $manager->has_credentials() ) {
 			WP_CLI::log( "Credentials for '{$platform}' not found. Let's set them up." );
-
-			// For now, we only support Shopify.
-			if ( 'shopify' !== $platform ) {
-				WP_CLI::error( "The specified platform '{$platform}' is not supported for automatic setup." );
-			}
-
-			$required_fields = array(
-				'api_key'  => 'Enter your Shopify API Access Token:',
-				'shop_url' => 'Enter your Shopify store URL (e.g., my-store.myshopify.com):',
-			);
-
-			$credentials = $manager->prompt_for_credentials( $required_fields );
-			$manager->save_credentials( $credentials );
-
+			$this->handle_credential_setup( $platform );
 			WP_CLI::success( 'Credentials saved successfully. Please run the command again to begin the migration.' );
 			return;
 		}

--- a/src/CLI/Commands/class-products-command.php
+++ b/src/CLI/Commands/class-products-command.php
@@ -9,24 +9,56 @@ declare( strict_types=1 );
 
 namespace WooCommerce\Migrator\CLI\Commands;
 
+use WooCommerce\Migrator\CLI\CredentialManager;
 use WP_CLI;
 
 /**
  * The class for the `wc migrate products` command.
  */
-class ProductsCommand {
+class ProductsCommand extends BaseCommand {
 
 	/**
 	 * The handler for the `wc migrate products` command.
 	 *
 	 * This is a placeholder and will be replaced by the controller logic.
 	 *
+	 * [--platform=<platform>]
+	 * : The platform to migrate products from.
+	 * ---
+	 * default: shopify
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
-	public function __invoke( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	public function __invoke( array $args, array $assoc_args ) {
+		$platform = $this->get_platform( $assoc_args );
+		$manager  = new CredentialManager( $platform );
+
+		if ( ! $manager->has_credentials() ) {
+			WP_CLI::log( "Credentials for '{$platform}' not found. Let's set them up." );
+
+			// For now, we only support Shopify.
+			if ( 'shopify' !== $platform ) {
+				WP_CLI::error( "The specified platform '{$platform}' is not supported for automatic setup." );
+			}
+
+			$required_fields = array(
+				'api_key'  => 'Enter your Shopify API Access Token:',
+				'shop_url' => 'Enter your Shopify store URL (e.g., my-store.myshopify.com):',
+			);
+
+			$credentials = $manager->prompt_for_credentials( $required_fields );
+			$manager->save_credentials( $credentials );
+
+			WP_CLI::success( 'Credentials saved successfully. Please run the command again to begin the migration.' );
+			return;
+		}
+
 		// The logic will be handled by the Products_Controller.
-		// For now, we just show a success message.
-		WP_CLI::success( 'Product migration command registered successfully!' );
+		// For now, we just show a success message if credentials exist.
+		WP_CLI::success( 'Credentials found. Proceeding with migration...' );
 	}
 }

--- a/src/CLI/Commands/class-reset-command.php
+++ b/src/CLI/Commands/class-reset-command.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * The Reset command.
+ *
+ * @package WooCommerce\Migrator\CLI\Commands
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Migrator\CLI\Commands;
+
+use WooCommerce\Migrator\CLI\CredentialManager;
+use WP_CLI;
+
+/**
+ * The command for resetting platform credentials.
+ */
+class ResetCommand extends BaseCommand {
+
+	/**
+	 * Resets (deletes) the credentials for a given platform.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--platform=<platform>]
+	 * : The platform to reset credentials for. Defaults to 'shopify'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc migrate reset
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ) {
+		$platform = $this->get_platform( $assoc_args );
+		$manager  = new CredentialManager( $platform );
+
+		if ( ! $manager->has_credentials() ) {
+			WP_CLI::warning( "No credentials found for '{$platform}' to reset." );
+			return;
+		}
+
+		$manager->delete_credentials();
+
+		WP_CLI::success( "Credentials for the '{$platform}' platform have been cleared." );
+	}
+}

--- a/src/CLI/Commands/class-setup-command.php
+++ b/src/CLI/Commands/class-setup-command.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * The Setup command.
+ *
+ * @package WooCommerce\Migrator\CLI\Commands
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Migrator\CLI\Commands;
+
+use WooCommerce\Migrator\CLI\CredentialManager;
+use WP_CLI;
+
+/**
+ * The command for interactively setting up platform credentials.
+ */
+class SetupCommand extends BaseCommand {
+
+	/**
+	 * Sets up the credentials for a given platform.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--platform=<platform>]
+	 * : The platform to set up credentials for. Defaults to 'shopify'.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp wc migrate setup
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ) {
+		$platform = $this->get_platform( $assoc_args );
+		$manager  = new CredentialManager( $platform );
+
+		// For now, we only support Shopify.
+		// This can be extended later with a factory or registry.
+		if ( 'shopify' !== $platform ) {
+			WP_CLI::error( "The specified platform '{$platform}' is not supported." );
+		}
+
+		WP_CLI::log( 'Configuring credentials for Shopify...' );
+
+		$required_fields = array(
+			'api_key'  => 'Enter your Shopify API Access Token:',
+			'shop_url' => 'Enter your Shopify store URL (e.g., my-store.myshopify.com):',
+		);
+
+		$credentials = $manager->prompt_for_credentials( $required_fields );
+		$manager->save_credentials( $credentials );
+
+		WP_CLI::success( 'Credentials saved successfully.' );
+	}
+}

--- a/src/CLI/Commands/class-setup-command.php
+++ b/src/CLI/Commands/class-setup-command.php
@@ -34,24 +34,7 @@ class SetupCommand extends BaseCommand {
 	 */
 	public function __invoke( array $args, array $assoc_args ) {
 		$platform = $this->get_platform( $assoc_args );
-		$manager  = new CredentialManager( $platform );
-
-		// For now, we only support Shopify.
-		// This can be extended later with a factory or registry.
-		if ( 'shopify' !== $platform ) {
-			WP_CLI::error( "The specified platform '{$platform}' is not supported." );
-		}
-
-		WP_CLI::log( 'Configuring credentials for ' . ucfirst( $platform ) . '...' );
-
-		$required_fields = array(
-			'api_key'  => 'Enter your Shopify API Access Token:',
-			'shop_url' => 'Enter your Shopify store URL (e.g., my-store.myshopify.com):',
-		);
-
-		$credentials = $manager->prompt_for_credentials( $required_fields );
-		$manager->save_credentials( $credentials );
-
+		$this->handle_credential_setup( $platform );
 		WP_CLI::success( 'Credentials saved successfully.' );
 	}
 }

--- a/src/CLI/Commands/class-setup-command.php
+++ b/src/CLI/Commands/class-setup-command.php
@@ -42,7 +42,7 @@ class SetupCommand extends BaseCommand {
 			WP_CLI::error( "The specified platform '{$platform}' is not supported." );
 		}
 
-		WP_CLI::log( 'Configuring credentials for Shopify...' );
+		WP_CLI::log( 'Configuring credentials for ' . ucfirst( $platform ) . '...' );
 
 		$required_fields = array(
 			'api_key'  => 'Enter your Shopify API Access Token:',

--- a/src/CLI/class-cli.php
+++ b/src/CLI/class-cli.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 namespace WooCommerce\Migrator\CLI;
 
 use WooCommerce\Migrator\CLI\Commands\ProductsCommand;
+use WooCommerce\Migrator\CLI\Commands\ResetCommand;
+use WooCommerce\Migrator\CLI\Commands\SetupCommand;
 
 /**
  * Main class for registering the WP-CLI commands.
@@ -36,6 +38,22 @@ class CLI {
 	 * Registers the WP-CLI commands.
 	 */
 	public function register_commands() {
+		$this->registrar->add_command(
+			'wc migrate setup',
+			SetupCommand::class,
+			array(
+				'shortdesc' => 'Interactively sets up credentials for a given platform.',
+			)
+		);
+
+		$this->registrar->add_command(
+			'wc migrate reset',
+			ResetCommand::class,
+			array(
+				'shortdesc' => 'Resets (deletes) the credentials for a given platform.',
+			)
+		);
+
 		$this->registrar->add_command(
 			'wc migrate products',
 			ProductsCommand::class,

--- a/src/CLI/class-credential-manager.php
+++ b/src/CLI/class-credential-manager.php
@@ -113,7 +113,7 @@ class CredentialManager {
 			return WP_CLI::readline( $prompt );
 		}
 
-		echo esc_html( $prompt );
+		WP_CLI::line( $prompt );
 		return trim( fgets( STDIN ) );
 	}
 }

--- a/src/CLI/class-credential-manager.php
+++ b/src/CLI/class-credential-manager.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Credential Manager class
+ *
+ * @package WooCommerce\Migrator\CLI
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Migrator\CLI;
+
+use WP_CLI;
+
+/**
+ * Manages platform credentials.
+ */
+class CredentialManager {
+
+	/**
+	 * The slug of the platform (e.g., 'shopify').
+	 *
+	 * @var string
+	 */
+	private $platform_slug;
+
+	/**
+	 * The WordPress option name for storing credentials.
+	 *
+	 * @var string
+	 */
+	private $option_name;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $platform_slug The slug for the platform.
+	 */
+	public function __construct( string $platform_slug ) {
+		$this->platform_slug = $platform_slug;
+		$this->option_name   = "wc_migrator_credentials_{$platform_slug}";
+	}
+
+	/**
+	 * Retrieves the stored credentials.
+	 *
+	 * @return array|null An associative array of credentials, or null if not found.
+	 */
+	public function get_credentials() {
+		$credentials_json = get_option( $this->option_name, false );
+		if ( ! $credentials_json ) {
+			return null;
+		}
+
+		$credentials = json_decode( $credentials_json, true );
+
+		return is_array( $credentials ) ? $credentials : null;
+	}
+
+	/**
+	 * Checks if credentials exist.
+	 *
+	 * @return bool True if credentials exist, false otherwise.
+	 */
+	public function has_credentials(): bool {
+		$credentials = $this->get_credentials();
+
+		return ! empty( $credentials );
+	}
+
+	/**
+	 * Prompts the user for credentials via the command line.
+	 *
+	 * @param array $fields An associative array of fields to prompt for.
+	 *
+	 * @return array The collected credentials.
+	 */
+	public function prompt_for_credentials( array $fields ) {
+		$credentials = array();
+		foreach ( $fields as $key => $prompt ) {
+			$credentials[ $key ] = $this->readline( $prompt . ' ' );
+		}
+
+		return $credentials;
+	}
+
+	/**
+	 * Saves credentials to the database.
+	 *
+	 * @param array $credentials An associative array of credentials.
+	 */
+	public function save_credentials( array $credentials ) {
+		update_option( $this->option_name, wp_json_encode( $credentials ) );
+	}
+
+	/**
+	 * Deletes credentials from the database.
+	 */
+	public function delete_credentials() {
+		delete_option( $this->option_name );
+	}
+
+	/**
+	 * Reads a line from STDIN.
+	 *
+	 * A backward-compatible wrapper for WP_CLI::readline().
+	 *
+	 * @param string $prompt The prompt to show to the user.
+	 *
+	 * @return string
+	 */
+	private function readline( string $prompt ): string {
+		if ( method_exists( 'WP_CLI', 'readline' ) ) {
+			return WP_CLI::readline( $prompt );
+		}
+
+		echo esc_html( $prompt );
+		return trim( fgets( STDIN ) );
+	}
+}

--- a/tests/CLITest.php
+++ b/tests/CLITest.php
@@ -12,6 +12,8 @@ namespace WooCommerce\Migrator\Tests;
 use WooCommerce\Migrator\CLI\CLI;
 use WooCommerce\Migrator\CLI\CommandRegistrar;
 use WooCommerce\Migrator\CLI\Commands\ProductsCommand;
+use WooCommerce\Migrator\CLI\Commands\ResetCommand;
+use WooCommerce\Migrator\CLI\Commands\SetupCommand;
 
 /**
  * Test cases for CLI command registration.
@@ -19,18 +21,19 @@ use WooCommerce\Migrator\CLI\Commands\ProductsCommand;
 class CLITest extends TestCase {
 
 	/**
-	 * Test that the register_commands method registers the products command.
+	 * Test that the register_commands method registers all commands.
 	 */
-	public function test_register_commands_adds_products_command() {
+	public function test_register_commands_adds_all_commands() {
 		// Create a mock of the CommandRegistrar.
 		$registrar = $this->createMock( CommandRegistrar::class );
 
-		// Expect the add_command method to be called once with the correct parameters.
-		$registrar->expects( $this->once() )
+		// Expect the add_command method to be called three times with the correct parameters.
+		$registrar->expects( $this->exactly( 3 ) )
 			->method( 'add_command' )
-			->with(
-				'wc migrate products',
-				ProductsCommand::class
+			->withConsecutive(
+				array( 'wc migrate setup', SetupCommand::class, $this->anything() ),
+				array( 'wc migrate reset', ResetCommand::class, $this->anything() ),
+				array( 'wc migrate products', ProductsCommand::class, $this->anything() )
 			);
 
 		// Instantiate the CLI class with the mock registrar and call the method.

--- a/tests/CredentialFlowTest.php
+++ b/tests/CredentialFlowTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Credential Flow Test
+ *
+ * @package WooCommerce\Migrator\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Migrator\Tests;
+
+use WooCommerce\Migrator\CLI\Commands\ProductsCommand;
+use WooCommerce\Migrator\CLI\Commands\ResetCommand;
+use WooCommerce\Migrator\CLI\Commands\SetupCommand;
+use WP_CLI;
+
+/**
+ * Test cases for the credential management flow.
+ */
+class CredentialFlowTest extends TestCase {
+
+	/**
+	 * The name of the option used to store Shopify credentials.
+	 */
+	const SHOPIFY_OPTION_NAME = 'wc_migrator_credentials_shopify';
+
+	/**
+	 * Clean up options after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( self::SHOPIFY_OPTION_NAME );
+		WP_CLI::reset();
+	}
+
+	/**
+	 * Test that the reset command deletes the credentials.
+	 */
+	public function test_reset_command_deletes_credentials() {
+		update_option( self::SHOPIFY_OPTION_NAME, wp_json_encode( array( 'api_key' => 'test' ) ) );
+		$this->assertTrue( get_option( self::SHOPIFY_OPTION_NAME, false ) !== false );
+
+		$command = new ResetCommand();
+		$command( array(), array() );
+
+		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
+	}
+
+	/**
+	 * Test that the products command proceeds when credentials exist.
+	 */
+	public function test_products_command_proceeds_when_credentials_exist() {
+		update_option( self::SHOPIFY_OPTION_NAME, wp_json_encode( array( 'api_key' => 'test' ) ) );
+
+		$command = new ProductsCommand();
+		try {
+			$command( array(), array() );
+			// If we get here, no exception was thrown, which is what we want.
+			$this->assertTrue( true, 'ProductsCommand should succeed when credentials exist.' );
+		} catch ( \Exception $e ) {
+			$this->fail( 'ProductsCommand threw an exception even though credentials exist.' );
+		}
+	}
+
+	/**
+	 * Test that the products command prompts and saves credentials if they do not exist.
+	 */
+	public function test_products_command_prompts_for_credentials_if_not_set() {
+		delete_option( self::SHOPIFY_OPTION_NAME );
+		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
+
+		WP_CLI::set_readline_returns(
+			array(
+				'test_api_key',
+				'test-store.myshopify.com',
+			)
+		);
+
+		$command = new ProductsCommand();
+		$command( array(), array() );
+
+		$saved_credentials_json = get_option( self::SHOPIFY_OPTION_NAME, false );
+		$this->assertNotFalse( $saved_credentials_json );
+
+		$expected_credentials = array(
+			'api_key'  => 'test_api_key',
+			'shop_url' => 'test-store.myshopify.com',
+		);
+		$this->assertEquals( $expected_credentials, json_decode( $saved_credentials_json, true ) );
+	}
+
+	/**
+	 * Test that the setup command prompts for and saves credentials.
+	 */
+	public function test_setup_command_saves_credentials() {
+		delete_option( self::SHOPIFY_OPTION_NAME );
+		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
+
+		WP_CLI::set_readline_returns(
+			array(
+				'setup_api_key',
+				'setup-store.myshopify.com',
+			)
+		);
+
+		$command = new SetupCommand();
+		$command( array(), array() );
+
+		$saved_credentials_json = get_option( self::SHOPIFY_OPTION_NAME, false );
+		$this->assertNotFalse( $saved_credentials_json );
+
+		$expected_credentials = array(
+			'api_key'  => 'setup_api_key',
+			'shop_url' => 'setup-store.myshopify.com',
+		);
+		$this->assertEquals( $expected_credentials, json_decode( $saved_credentials_json, true ) );
+	}
+}

--- a/tests/CredentialFlowTest.php
+++ b/tests/CredentialFlowTest.php
@@ -27,7 +27,7 @@ class CredentialFlowTest extends TestCase {
 	/**
 	 * Clean up options after each test.
 	 */
-	public function tearDown() {
+	public function tearDown(): void { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
 		parent::tearDown();
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		WP_CLI::reset();

--- a/tests/CredentialFlowTest.php
+++ b/tests/CredentialFlowTest.php
@@ -27,7 +27,7 @@ class CredentialFlowTest extends TestCase {
 	/**
 	 * Clean up options after each test.
 	 */
-	public function tearDown(): void {
+	public function tearDown() {
 		parent::tearDown();
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		WP_CLI::reset();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,10 @@ declare( strict_types=1 );
 // Load the Composer autoloader to make all dependencies available.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
+// Load WP-CLI stubs.
+require_once __DIR__ . '/wp-cli-stubs.php';
+require_once __DIR__ . '/wp-cli-exit-exception-stub.php';
+
 // First, check if we're loaded from within a typical WP test environment.
 if ( ! defined( 'WP_TESTS_DIR' ) ) {
 	$wp_tests_dir = getenv( 'WP_TESTS_DIR' );

--- a/tests/wp-cli-exit-exception-stub.php
+++ b/tests/wp-cli-exit-exception-stub.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Stub for the WP_CLI_ExitException class for testing purposes.
+ *
+ * @package WooCommerce\Migrator\Tests
+ */
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing
+
+if ( ! class_exists( 'WP_CLI_ExitException' ) ) {
+	class WP_CLI_ExitException extends \Exception {}
+}
+
+// phpcs:enable 

--- a/tests/wp-cli-stubs.php
+++ b/tests/wp-cli-stubs.php
@@ -9,6 +9,11 @@
 
 if ( ! class_exists( 'WP_CLI' ) ) {
 	class WP_CLI {
+		/**
+		 * An array of mock return values for the readline method.
+		 *
+		 * @var array
+		 */
 		private static $readline_returns = array();
 
 		public static function set_readline_returns( array $values ) {

--- a/tests/wp-cli-stubs.php
+++ b/tests/wp-cli-stubs.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Stubs for WP-CLI classes and functions for testing purposes.
+ *
+ * @package WooCommerce\Migrator\Tests
+ */
+
+// phpcs:disable Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.Found, WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		private static $readline_returns = array();
+
+		public static function set_readline_returns( array $values ) {
+			self::$readline_returns = $values;
+		}
+
+		public static function reset() {
+			self::$readline_returns = array();
+		}
+
+		public static function success( $message ) {}
+		public static function warning( $message ) {}
+		public static function error( $message ) {
+			throw new WP_CLI_ExitException( $message );
+		}
+		public static function log( $message ) {}
+		public static function readline( $prompt ) {
+			return array_shift( self::$readline_returns );
+		}
+	}
+}
+
+// phpcs:enable


### PR DESCRIPTION
This pull request introduces the core functionality for managing platform credentials.

The key addition is the `CredentialManager` class, which centralizes all logic for handling credentials stored in WordPress options. To support this, new CLI commands (`setup`, `reset`) have been created, and existing commands have been updated to use this new system.

### Key Changes
-   **`CredentialManager` Class**: A new service class (`src/CLI/class-credential-manager.php`) to handle all credential operations (save, get, delete, prompt).
-   **New CLI Commands**:
    -   `wp wc migrate setup`: Interactively prompts the user for platform credentials.
    -   `wp wc migrate reset`: Clears any saved credentials for a given platform.
-   **Updated `products` Command**:
    -   If credentials are not found, it now automatically triggers the interactive setup flow instead of erroring.
    -   The `--platform` argument now correctly defaults to `shopify`.
-   **`BaseCommand` Refactoring**: Repeated logic for handling the default platform has been moved into a common `BaseCommand` class, which all commands now extend.
-   **Testing Framework**:
    -   Introduced test stubs for `WP_CLI` and `WP_CLI_ExitException` to enable robust testing of command logic.
    -   The `readline` stub now supports mock return values, allowing for precise testing of interactive flows.
    -   Added `CredentialFlowTest.php` with comprehensive coverage for the new features.
-   **Workflow & Standards**:
    -   The `composer test` script now automatically updates the autoloader.
    -   All new code has been linted and fixed to be compliant with the project's PHP compatibility and coding standards.

### Testing Instructions

#### Automated Tests

To run the automated tests, simply run the following command from the plugin's root directory. This will update dependencies, regenerate the autoloader, and run the full PHPUnit test suite.

```bash
composer test
```
**Expected Result:** The tests should complete with no errors or failures (7 tests, 12 assertions).

#### Manual Testing

**1. Test Automatic Credential Setup**

-   **Action:** Run the products command without having any credentials saved.
    ```bash
    wp wc migrate products
    ```
-   **Expected Result:**
    -   You should see the message: `Platform not specified, using default: 'shopify'.`
    -   You should see the message: `Credentials for 'shopify' not found. Let's set them up.`
    -   You will be prompted to enter an API key and a store URL.
    -   Enter any value for both.
    -   You should see the success message: `Credentials saved successfully. Please run the command again to begin the migration.`

**2. Test Command with Existing Credentials**

-   **Action:** Run the products command again.
    ```bash
    wp wc migrate products
    ```
-   **Expected Result:**
    -   You should see the "using default" message again.
    -   You should see the success message: `Credentials found. Proceeding with migration...`

**3. Test Manual Credential Setup**

-   **Action:** Use the `setup` command to overwrite the credentials.
    ```bash
    wp wc migrate setup
    ```
-   **Expected Result:**
    -   You will be prompted to enter a new API key and store URL.
    -   Enter new/different values.
    -   You should see the success message: `Credentials saved successfully.`

**4. Test Credential Reset**

-   **Action:** Run the `reset` command.
    ```bash
    wp wc migrate reset
    ```
-   **Expected Result:**
    -   You should see the success message: `Credentials for the 'shopify' platform have been cleared.`
    -   If you run `wp wc migrate products` again, you should be prompted to set up credentials from scratch, confirming they were deleted.