### PR TITLE
Update WordPress and WooCommerce Version Requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "require": {
-        "php": "^7.4"
+        "php": "^7.4 || ^8.0"
     },
     "scripts": {
         "lint": "phpcs",

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
+    "require": {
+        "php": "^7.4"
+    },
     "scripts": {
         "lint": "phpcs",
         "format": "phpcbf",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0623fc87794cdf1ae182fb305cc00048",
+    "content-hash": "038d21c1a81855d1d74917a85200be9f",
     "packages": [],
     "packages-dev": [
         {
@@ -2494,7 +2494,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": "^7.4 || ^8.0"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
 	<arg value="s"/>
 
 	<!-- Set the PHP test version for PHPCompatibility checks. -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core">

--- a/src/CLI/class-credential-manager.php
+++ b/src/CLI/class-credential-manager.php
@@ -21,14 +21,14 @@ class CredentialManager {
 	 *
 	 * @var string
 	 */
-	private $platform_slug;
+	private string $platform_slug;
 
 	/**
 	 * The WordPress option name for storing credentials.
 	 *
 	 * @var string
 	 */
-	private $option_name;
+	private string $option_name;
 
 	/**
 	 * Constructor.
@@ -45,7 +45,7 @@ class CredentialManager {
 	 *
 	 * @return array|null An associative array of credentials, or null if not found.
 	 */
-	public function get_credentials() {
+	public function get_credentials(): ?array {
 		$credentials_json = get_option( $this->option_name, false );
 		if ( ! $credentials_json ) {
 			return null;
@@ -74,7 +74,7 @@ class CredentialManager {
 	 *
 	 * @return array The collected credentials.
 	 */
-	public function prompt_for_credentials( array $fields ) {
+	public function prompt_for_credentials( array $fields ): array {
 		$credentials = array();
 		foreach ( $fields as $key => $prompt ) {
 			$credentials[ $key ] = $this->readline( $prompt . ' ' );
@@ -88,14 +88,14 @@ class CredentialManager {
 	 *
 	 * @param array $credentials An associative array of credentials.
 	 */
-	public function save_credentials( array $credentials ) {
+	public function save_credentials( array $credentials ): void {
 		update_option( $this->option_name, wp_json_encode( $credentials ) );
 	}
 
 	/**
 	 * Deletes credentials from the database.
 	 */
-	public function delete_credentials() {
+	public function delete_credentials(): void {
 		delete_option( $this->option_name );
 	}
 

--- a/tests/CredentialFlowTest.php
+++ b/tests/CredentialFlowTest.php
@@ -37,15 +37,12 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the reset command deletes the credentials.
 	 */
 	public function test_reset_command_deletes_credentials() {
-		// Arrange: Manually set the credential option.
 		update_option( self::SHOPIFY_OPTION_NAME, wp_json_encode( array( 'api_key' => 'test' ) ) );
 		$this->assertTrue( get_option( self::SHOPIFY_OPTION_NAME, false ) !== false );
 
-		// Act: Execute the reset command.
 		$command = new ResetCommand();
 		$command( array(), array() );
 
-		// Assert: Retrieve the option and assert that it no longer exists.
 		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
 	}
 
@@ -56,8 +53,6 @@ class CredentialFlowTest extends TestCase {
 		// Arrange: Manually set the credential option.
 		update_option( self::SHOPIFY_OPTION_NAME, wp_json_encode( array( 'api_key' => 'test' ) ) );
 
-		// Act & Assert: Execute the command and expect a success message.
-		// We can't easily capture output, but we can confirm it doesn't error out.
 		$command = new ProductsCommand();
 		try {
 			$command( array(), array() );
@@ -72,11 +67,9 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the products command prompts and saves credentials if they do not exist.
 	 */
 	public function test_products_command_prompts_for_credentials_if_not_set() {
-		// Arrange: Ensure the option is deleted.
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
 
-		// Arrange: Set the mock return values for the readline prompt.
 		WP_CLI::set_readline_returns(
 			array(
 				'test_api_key',
@@ -84,11 +77,9 @@ class CredentialFlowTest extends TestCase {
 			)
 		);
 
-		// Act: Run the products command.
 		$command = new ProductsCommand();
 		$command( array(), array() );
 
-		// Assert: Check that credentials have been saved.
 		$saved_credentials_json = get_option( self::SHOPIFY_OPTION_NAME, false );
 		$this->assertNotFalse( $saved_credentials_json );
 
@@ -103,7 +94,6 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the setup command prompts for and saves credentials.
 	 */
 	public function test_setup_command_saves_credentials() {
-		// Arrange: Ensure the option is deleted.
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
 
@@ -115,7 +105,6 @@ class CredentialFlowTest extends TestCase {
 			)
 		);
 
-		// Act: Run the setup command.
 		$command = new SetupCommand();
 		$command( array(), array() );
 

--- a/tests/CredentialFlowTest.php
+++ b/tests/CredentialFlowTest.php
@@ -27,7 +27,7 @@ class CredentialFlowTest extends TestCase {
 	/**
 	 * Clean up options after each test.
 	 */
-	public function tearDown(): void { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
+	public function tearDown(): void {
 		parent::tearDown();
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		WP_CLI::reset();
@@ -37,12 +37,15 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the reset command deletes the credentials.
 	 */
 	public function test_reset_command_deletes_credentials() {
+		// Arrange: Manually set the credential option.
 		update_option( self::SHOPIFY_OPTION_NAME, wp_json_encode( array( 'api_key' => 'test' ) ) );
 		$this->assertTrue( get_option( self::SHOPIFY_OPTION_NAME, false ) !== false );
 
+		// Act: Execute the reset command.
 		$command = new ResetCommand();
 		$command( array(), array() );
 
+		// Assert: Retrieve the option and assert that it no longer exists.
 		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
 	}
 
@@ -50,8 +53,11 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the products command proceeds when credentials exist.
 	 */
 	public function test_products_command_proceeds_when_credentials_exist() {
+		// Arrange: Manually set the credential option.
 		update_option( self::SHOPIFY_OPTION_NAME, wp_json_encode( array( 'api_key' => 'test' ) ) );
 
+		// Act & Assert: Execute the command and expect a success message.
+		// We can't easily capture output, but we can confirm it doesn't error out.
 		$command = new ProductsCommand();
 		try {
 			$command( array(), array() );
@@ -66,9 +72,11 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the products command prompts and saves credentials if they do not exist.
 	 */
 	public function test_products_command_prompts_for_credentials_if_not_set() {
+		// Arrange: Ensure the option is deleted.
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
 
+		// Arrange: Set the mock return values for the readline prompt.
 		WP_CLI::set_readline_returns(
 			array(
 				'test_api_key',
@@ -76,9 +84,11 @@ class CredentialFlowTest extends TestCase {
 			)
 		);
 
+		// Act: Run the products command.
 		$command = new ProductsCommand();
 		$command( array(), array() );
 
+		// Assert: Check that credentials have been saved.
 		$saved_credentials_json = get_option( self::SHOPIFY_OPTION_NAME, false );
 		$this->assertNotFalse( $saved_credentials_json );
 
@@ -93,9 +103,11 @@ class CredentialFlowTest extends TestCase {
 	 * Test that the setup command prompts for and saves credentials.
 	 */
 	public function test_setup_command_saves_credentials() {
+		// Arrange: Ensure the option is deleted.
 		delete_option( self::SHOPIFY_OPTION_NAME );
 		$this->assertFalse( get_option( self::SHOPIFY_OPTION_NAME, false ) );
 
+		// Arrange: Set the mock return values for the readline prompt.
 		WP_CLI::set_readline_returns(
 			array(
 				'setup_api_key',
@@ -103,9 +115,11 @@ class CredentialFlowTest extends TestCase {
 			)
 		);
 
+		// Act: Run the setup command.
 		$command = new SetupCommand();
 		$command( array(), array() );
 
+		// Assert: Check that credentials have been saved.
 		$saved_credentials_json = get_option( self::SHOPIFY_OPTION_NAME, false );
 		$this->assertNotFalse( $saved_credentials_json );
 

--- a/woocommerce-migrator.php
+++ b/woocommerce-migrator.php
@@ -1,16 +1,19 @@
 <?php
 /**
- * Plugin Name:     WooCommerce Migrator
- * Plugin URI:      https://github.com/woocommerce/woocommerce-migrator
- * Description:     CLI commands to migrate data to WooCommerce from other platforms.
- * Version:         1.0.0
- * Author:          WooCommerce
- * Author URI:      https://woocommerce.com
- * License:         GPL-3.0-or-later
- * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
- * Text Domain:     woocommerce-migrator
+ * Plugin Name:          WooCommerce Migrator
+ * Plugin URI:           https://github.com/woocommerce/woocommerce-migrator
+ * Description:          CLI commands to migrate data to WooCommerce from other platforms.
+ * Version:              1.0.0
+ * Author:               WooCommerce
+ * Author URI:           https://woocommerce.com
+ * License:              GPL-3.0-or-later
+ * License URI:          https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain:          woocommerce-migrator
+ * Requires PHP:         7.4
+ * Requires at least:    6.3
+ * WC requires at least: 8.9
  *
- * @package         WooCommerce\Migrator
+ * @package              WooCommerce\Migrator
  */
 
 declare( strict_types=1 );


### PR DESCRIPTION
This is a small maintenance update to align the plugin's declared compatibility with its dependencies.

-   Sets the minimum required WordPress version to `6.3` in the plugin header.
-   Sets the minimum required WooCommerce version to `8.9` in the plugin header.
-   Aligns the docblock comments in `woocommerce-migrator.php` for improved readability and style consistency.