### PR TITLE
Added list command wp wc migrate list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "scripts": {
         "lint": "phpcs",
         "format": "phpcbf",
+        "dump": "composer dump-autoload -o",
         "test:setup": "bash bin/install-wp-tests.sh ${DB_NAME:-test_db} ${DB_USER:-root} ${DB_PASS:-''} ${DB_HOST:-localhost}",
         "test": [
             "composer dump-autoload -o",

--- a/src/CLI/Commands/class-list-command.php
+++ b/src/CLI/Commands/class-list-command.php
@@ -21,13 +21,9 @@ class List_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp wc migrate list
-	 *
-	 * @param array $args       Positional arguments.
-	 * @param array $assoc_args Associative arguments.
-	 *
-	 * @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	 */
-	public function __invoke( $args, $assoc_args ) {
+	public function __invoke() {
+
 		$registry  = PlatformRegistry::get_instance();
 		$platforms = $registry->get_platforms();
 

--- a/src/CLI/Commands/class-list-command.php
+++ b/src/CLI/Commands/class-list-command.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Migrator\CLI\Commands
  */
 
- declare( strict_types=1 );
+declare( strict_types=1 );
 
 namespace WooCommerce\Migrator\CLI\Commands;
 

--- a/src/CLI/Commands/class-list-command.php
+++ b/src/CLI/Commands/class-list-command.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Migrator\CLI\Commands
  */
 
+ declare( strict_types=1 );
+
 namespace WooCommerce\Migrator\CLI\Commands;
 
 use WooCommerce\Migrator\Core\PlatformRegistry;

--- a/src/CLI/Commands/class-list-command.php
+++ b/src/CLI/Commands/class-list-command.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Platforms List Command
+ *
+ * @package WooCommerce\Migrator\CLI\Commands
+ */
+
+namespace WooCommerce\Migrator\CLI\Commands;
+
+use WooCommerce\Migrator\Core\PlatformRegistry;
+use WP_CLI;
+
+/**
+ * Lists all registered migration platforms.
+ */
+class List_Command {
+
+	/**
+	 * Lists all registered migration platforms.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp wc migrate list
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 *
+	 * @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$registry  = PlatformRegistry::get_instance();
+		$platforms = $registry->get_platforms();
+
+		if ( empty( $platforms ) ) {
+			WP_CLI::line( 'No migration platforms are registered.' );
+			return;
+		}
+
+		$formatted_items = array();
+		foreach ( $platforms as $id => $details ) {
+			$formatted_items[] = array(
+				'id'      => $id,
+				'name'    => $details['name'] ?? '',
+				'fetcher' => $details['fetcher'] ?? '',
+				'mapper'  => $details['mapper'] ?? '',
+			);
+		}
+
+		WP_CLI\Utils\format_items(
+			'table',
+			$formatted_items,
+			array( 'id', 'name', 'fetcher', 'mapper' )
+		);
+	}
+}

--- a/src/CLI/class-cli.php
+++ b/src/CLI/class-cli.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WooCommerce\Migrator\CLI;
 
+use WooCommerce\Migrator\CLI\Commands\List_Command;
 use WooCommerce\Migrator\CLI\Commands\ProductsCommand;
 use WooCommerce\Migrator\CLI\Commands\ResetCommand;
 use WooCommerce\Migrator\CLI\Commands\SetupCommand;
@@ -38,6 +39,14 @@ class CLI {
 	 * Registers the WP-CLI commands.
 	 */
 	public function register_commands() {
+		$this->registrar->add_command(
+			'wc migrate list',
+			List_Command::class,
+			array(
+				'shortdesc' => 'Lists all registered migration platforms.',
+			)
+		);
+
 		$this->registrar->add_command(
 			'wc migrate setup',
 			SetupCommand::class,

--- a/tests/CLITest.php
+++ b/tests/CLITest.php
@@ -11,6 +11,7 @@ namespace WooCommerce\Migrator\Tests;
 
 use WooCommerce\Migrator\CLI\CLI;
 use WooCommerce\Migrator\CLI\CommandRegistrar;
+use WooCommerce\Migrator\CLI\Commands\List_Command;
 use WooCommerce\Migrator\CLI\Commands\ProductsCommand;
 use WooCommerce\Migrator\CLI\Commands\ResetCommand;
 use WooCommerce\Migrator\CLI\Commands\SetupCommand;
@@ -28,9 +29,10 @@ class CLITest extends TestCase {
 		$registrar = $this->createMock( CommandRegistrar::class );
 
 		// Expect the add_command method to be called three times with the correct parameters.
-		$registrar->expects( $this->exactly( 3 ) )
+		$registrar->expects( $this->exactly( 4 ) )
 			->method( 'add_command' )
 			->withConsecutive(
+				array( 'wc migrate list', List_Command::class, $this->anything() ),
 				array( 'wc migrate setup', SetupCommand::class, $this->anything() ),
 				array( 'wc migrate reset', ResetCommand::class, $this->anything() ),
 				array( 'wc migrate products', ProductsCommand::class, $this->anything() )


### PR DESCRIPTION
This pull request introduces a new WP-CLI command, `wp wc migrate list`, to provide developers and users with an easy way to see all available migration source platforms that have been registered with the system.

This command improves the plugin's usability and introspection capabilities, making it simpler to verify which platforms are active and available for migrations.

Also I added a handy script to autoload the composer, if a new platform register. Helps in testing.

### Changes Proposed in This Pull Request

*   **New `List_Command` Class:**
    *   Created a new command class at `src/CLI/Commands/class-list-command.php`.
    *   This class uses the `PlatformRegistry` to fetch the list of all registered platforms.
    *   It leverages the standard `WP_CLI\Utils\format_items()` utility to display the platforms in a clean, formatted table.
    *   It includes a user-friendly message for when no platforms are currently registered.

*   **Command Registration:**
    *   The new `wc migrate list` command has been registered in the main `src/CLI/class-cli.php` file, making it accessible through WP-CLI.

### Testing Instructions

You can verify this new command by testing two scenarios: when no platforms are registered, and when a platform is registered.

#### 1. Test With No Platforms Registered

1.  Ensure no temporary platform registration code (like the one below) is active in your test environment.
2.  Run the command from your terminal:
    ```bash
    wp wc migrate list
    ```
3.  **Expected Result:** You should see a message indicating that no platforms are available.
    ```
    No migration platforms are registered.
    ```

#### 2. Test With a Registered Platform

1.  Add the following temporary PHP snippet to your theme's `functions.php` file or a temporary plugin to simulate a platform being registered.
    ```php
    add_filter( 'wc_migrator_register_platform', function( $platforms ) {
        $platforms['my-test-platform'] = array(
            'name'    => 'My Awesome Test Platform',
            'fetcher' => 'WooCommerce\\Migrator\\Tests\\Mocks\\MockFetcher',
            'mapper'  => 'WooCommerce\\Migrator\\Tests\\Mocks\\MockMapper',
        );
        return $platforms;
    } );
    ```
2.  Run the command again from your terminal:
    ```bash
    wp wc migrate list
    ```
3.  **Expected Result:** You should see a table listing the dummy platform you just registered.
    ```
    +--------------------+--------------------------+-------------------------------------------------+-----------------------------------------------+
    | id                 | name                     | fetcher                                         | mapper                                        |
    +--------------------+--------------------------+-------------------------------------------------+-----------------------------------------------+
    | my-test-platform   | My Awesome Test Platform | WooCommerce\Migrator\Tests\Mocks\MockFetcher    | WooCommerce\Migrator\Tests\Mocks\MockMapper   |
    +--------------------+--------------------------+-------------------------------------------------+-----------------------------------------------+
    ```